### PR TITLE
Use a gradient scale rather than a threshold scale

### DIFF
--- a/frontend/dist/bundle.js
+++ b/frontend/dist/bundle.js
@@ -213,7 +213,7 @@ var g = svg.append("g");
 
 svg.call(zoom);
 
-var color = d3.scaleThreshold().domain([25000, 50000, 75000, 100000, 150000, 200000, 300000, 450000, 600000, 1000000, 2000000]).range(d3.schemeOrRd[9]);
+var color = d3.scaleLinear().domain([25000, 50000, 75000, 100000, 150000, 200000, 300000, 450000, 600000, 1000000, 2000000]).range(d3.schemeOrRd[9]);
 
 var oldGranularity = district;
 var DISTRICT_THRESHOLD = 3;

--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -144,7 +144,7 @@ var g = svg.append("g");
 
 svg.call(zoom)
 
-var color = d3.scaleThreshold()
+var color = d3.scaleLinear()
     .domain([25000, 50000, 75000, 100000, 150000, 200000, 300000, 450000, 600000, 1000000, 2000000])
     .range(d3.schemeOrRd[9])
 


### PR DESCRIPTION
Makes for smoother transitions between areas, and more differentiation
between similar areas